### PR TITLE
Refactor: 학생 인증 폼 리팩토링

### DIFF
--- a/src/pages/auth-request/AuthRequest.tsx
+++ b/src/pages/auth-request/AuthRequest.tsx
@@ -1,63 +1,22 @@
-// 건국대학교 학생 인증
-import { useForm, type SubmitHandler } from 'react-hook-form';
+import { useEmailAuthForm } from './useEmailAuthForm';
 import UserInput from '../../shared/components/UserInput';
-import { useState } from 'react';
-import { requestAuthCode } from '../../shared/apis/auth/auth';
-// import { useNavigate } from 'react-router-dom';
-
-type AuthRequestProps = {
-  userEmail: string;
-  authNumber: string;
-};
 
 const AuthRequest = () => {
   const {
-    register,
-    handleSubmit,
-    watch,
-    formState: { errors },
-  } = useForm<AuthRequestProps>({
-    mode: 'onChange',
-  });
-
-  const [showEnterAuth, setShowEnterAuth] = useState(false);
-
-  const onSubmit: SubmitHandler<AuthRequestProps> = async (data) => {
-    console.log('폼 제출 성공!', data);
-  };
-
-  const userEmail = watch('userEmail');
-  const authNumber = watch('authNumber');
-  //   const navigate = useNavigate();
-
-  const handleRequestAuthNum = async () => {
-    console.log('인증번호 요청됨');
-    try {
-      const response = await requestAuthCode(userEmail);
-      console.log(response);
-      if (!response.data.isVerified) {
-        // 인증정보 기억 안돼있으면
-        setShowEnterAuth(true); // 인증번호 입력 필드 보여주기
-      } else {
-        // 인증정보 기억 돼있으면 바로 개방요청 보내기
-      }
-    } catch {
-      alert('인증번호 요청 오류가 발생했습니다.');
-    }
-  };
-
-  const handleVerifyAuthNum = () => {
-    console.log('인증정보 확인 요청됨');
-    try {
-      //
-    } catch {
-      alert('인증정보 확인 오류가 발생했습니다.');
-    }
-  };
-
-  const handleBack = () => {
-    // 뒤로가기
-  };
+    registerEmail,
+    handleSubmitEmail,
+    errorsEmail,
+    isValidEmail,
+    // userEmail,
+    registerAuth,
+    handleSubmitAuth,
+    errorsAuth,
+    authNumber,
+    showEnterAuth,
+    onSubmitEmail,
+    onSubmitAuth,
+    handleBack,
+  } = useEmailAuthForm();
 
   return (
     <div className="w-full">
@@ -65,60 +24,58 @@ const AuthRequest = () => {
         <h1 className="form-title">건국대학교 학생 인증</h1>
 
         <main className="mt-6">
-          <form
-            onSubmit={handleSubmit(onSubmit)}
-            className="flex w-full flex-col items-center gap-2"
-          >
-            <div className="flex gap-2">
-              <UserInput
-                registerName="userEmail"
-                placeholder="건국대학교 이메일을 입력해주세요"
-                register={register}
-                error={errors.userEmail}
-                rules={{
-                  required: '이메일을 입력해주세요.',
-                  pattern: {
-                    value: /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/,
-                    message: '올바른 이메일 형식이 아닙니다.',
-                  },
-                }}
-                width="24rem"
-              />
+          {/* 이메일 입력 폼 */}
+          {!showEnterAuth && (
+            <form
+              onSubmit={handleSubmitEmail(onSubmitEmail)}
+              className="flex w-full flex-col items-center gap-2"
+            >
+              <div className="flex gap-2">
+                <UserInput
+                  registerName="userEmail"
+                  placeholder="건국대학교 이메일을 입력해주세요"
+                  register={registerEmail}
+                  error={errorsEmail.userEmail}
+                  rules={{
+                    required: '이메일을 입력해주세요.',
+                    pattern: {
+                      value: /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/,
+                      message: '올바른 이메일 형식이 아닙니다.',
+                    },
+                  }}
+                  width="24rem"
+                />
+                <button type="submit" className="form-button" disabled={!isValidEmail}>
+                  학생 인증하기
+                </button>
+              </div>
+            </form>
+          )}
 
-              <button
-                type="button"
-                className="form-button"
-                disabled={!userEmail}
-                onClick={handleRequestAuthNum}
-              >
-                학생 인증하기
-              </button>
-            </div>
-
-            {showEnterAuth && (
+          {/* 인증번호 입력 폼 */}
+          {showEnterAuth && (
+            <form
+              onSubmit={handleSubmitAuth(onSubmitAuth)}
+              className="flex w-full flex-col items-center gap-2"
+            >
               <div className="flex gap-2">
                 <UserInput
                   registerName="authNumber"
                   type="number"
                   placeholder="인증번호를 입력해주세요"
-                  register={register}
-                  error={errors.authNumber}
+                  register={registerAuth}
+                  error={errorsAuth.authNumber}
                   rules={{
                     required: '인증번호를 입력해주세요.',
                   }}
                   width="24rem"
                 />
-                <button
-                  type="button"
-                  className="form-button"
-                  disabled={!authNumber}
-                  onClick={handleVerifyAuthNum}
-                >
+                <button type="submit" className="form-button" disabled={!authNumber}>
                   인증번호 입력
                 </button>
               </div>
-            )}
-          </form>
+            </form>
+          )}
         </main>
 
         <div className="mt-4 flex text-[1.2rem]">

--- a/src/pages/auth-request/useEmailAuthForm.ts
+++ b/src/pages/auth-request/useEmailAuthForm.ts
@@ -1,0 +1,79 @@
+import { useForm, type SubmitHandler } from 'react-hook-form';
+import { useState } from 'react';
+import { requestAuthCode, verifyAuthCode } from '../../shared/apis/auth/auth';
+
+export const useEmailAuthForm = () => {
+  // 이메일 입력 폼
+  const {
+    register: registerEmail,
+    handleSubmit: handleSubmitEmail,
+    watch: watchEmail,
+    formState: { errors: errorsEmail, isValid: isValidEmail },
+  } = useForm<{ userEmail: string }>({ mode: 'onChange' });
+
+  // 인증번호 입력 폼
+  const {
+    register: registerAuth,
+    handleSubmit: handleSubmitAuth,
+    watch: watchAuth,
+    formState: { errors: errorsAuth },
+  } = useForm<{ authNumber: number }>({ mode: 'onChange' });
+
+  const [showEnterAuth, setShowEnterAuth] = useState(false);
+
+  const userEmail = watchEmail('userEmail');
+  const authNumber = watchAuth('authNumber');
+
+  // 이메일 제출 처리
+  const onSubmitEmail: SubmitHandler<{ userEmail: string }> = async (data) => {
+    console.log('이메일 제출 성공!', data);
+    try {
+      const response = await requestAuthCode(userEmail);
+      console.log(response);
+      if (!response.data.isVerified) {
+        setShowEnterAuth(true); // 인증번호 입력 필드 보여주기
+      } else {
+        // 인증정보 기억돼있으면 바로 개방요청 처리 가능
+      }
+    } catch {
+      alert('인증번호 요청 오류가 발생했습니다.');
+    }
+  };
+
+  // 인증번호 제출 처리
+  const onSubmitAuth: SubmitHandler<{ authNumber: number }> = async (data) => {
+    console.log('인증번호 제출 성공!', data);
+    console.log('인증정보 확인 요청됨');
+    try {
+      const response = await verifyAuthCode(userEmail, authNumber);
+      if (response.code === 200) {
+        // 인증 성공, accessToken 저장 등 처리
+      }
+    } catch {
+      alert('인증정보 확인 오류가 발생했습니다.');
+    }
+  };
+
+  const handleBack = () => setShowEnterAuth(false);
+
+  return {
+    // 이메일 관련
+    registerEmail,
+    handleSubmitEmail,
+    errorsEmail,
+    isValidEmail,
+    userEmail,
+    // 인증번호 관련
+    registerAuth,
+    handleSubmitAuth,
+    errorsAuth,
+    authNumber,
+    // 상태
+    showEnterAuth,
+    setShowEnterAuth,
+    // 액션
+    onSubmitEmail,
+    onSubmitAuth,
+    handleBack,
+  };
+};

--- a/src/shared/apis/auth/auth.ts
+++ b/src/shared/apis/auth/auth.ts
@@ -9,3 +9,13 @@ export const requestAuthCode = async (userEmail: string) => {
   const response = await apiClient.post(API.AUTH.REQUEST_AUTH_CODE, requestBody);
   return response.data;
 };
+
+export const verifyAuthCode = async (userEmail: string, code: number) => {
+  const requestBody = {
+    email: userEmail,
+    code: code,
+  };
+
+  const response = await apiClient.post(API.AUTH.VERIFY_AUTH_CODE, requestBody);
+  return response.data;
+};


### PR DESCRIPTION
# 🩺 Pull requests
### 📍 작업한 이슈번호
- #3 

### 💻 작업한 내용
- 인증로직 및 상태관리 코드 커스텀 훅으로 분리
- email과 authcode를 두 개의 form으로 분리
- 인증코드 검증 api 구현(아직 테스트 x)

### 📢 PR Point
- email인증요청의 응답에서 isVerified가 true인 경우와 인증번호검증요청의 응답에서 accessToken을 받아온 경우는 아직 테스트하지 못함

### 📸 스크린샷
