### PR TITLE
[Design] UI 세부디테일(hover 밑 클릭시 색상) 추가

### DIFF
--- a/src/pages/auth-keyLoacation/AuthKeyLocation.tsx
+++ b/src/pages/auth-keyLoacation/AuthKeyLocation.tsx
@@ -1,7 +1,11 @@
+import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const KeyLocationPage = () => {
   const navigate = useNavigate();
+
+  const buildings = ['새천년관', '공학관', '신공학관'];
+  const [selectedBuilding, setSelectedBuilding] = useState(buildings[0]);
 
   // 버튼 클릭 핸들러
   const handleClick = (label: string) => {
@@ -12,11 +16,18 @@ const KeyLocationPage = () => {
     <div className="flex flex-col items-center space-y-6 px-4 py-6 text-sm">
       {/* 건물 버튼 */}
       <div className="flex justify-center space-x-4">
-        {['새천년관', '공학관', '신공학관'].map((name) => (
+        {buildings.map((name) => (
           <button
             key={name}
-            className="rounded border border-green-800 px-4 py-1 font-semibold text-green-800"
-            onClick={() => handleClick(name)}
+            className={`rounded border px-4 py-1 font-semibold ${
+              selectedBuilding === name
+                ? 'bg-green-800 text-white'
+                : 'border-green-800 text-green-800'
+            } `}
+            onClick={() => {
+              setSelectedBuilding(name);
+              handleClick(name);
+            }}
           >
             {name}
           </button>
@@ -38,7 +49,10 @@ const KeyLocationPage = () => {
 
       {/* 기록 추가 버튼 */}
       <div className="flex w-full justify-end pr-1">
-        <button className="rounded border px-4 py-1 text-sm" onClick={() => navigate('/register')}>
+        <button
+          className="cursor-pointer rounded border px-4 py-1 text-sm hover:bg-green-800 hover:text-white"
+          onClick={() => navigate('/register')}
+        >
           기록 추가
         </button>
       </div>
@@ -48,7 +62,7 @@ const KeyLocationPage = () => {
         {['개방관리', '키 관리', '로그아웃'].map((label) => (
           <button
             key={label}
-            className="w-full rounded border border-green-800 py-1 font-semibold text-green-800"
+            className="w-full cursor-pointer rounded border border-green-800 py-1 font-semibold text-green-800 hover:bg-green-800 hover:text-white"
             onClick={() => handleClick(label)}
           >
             {label}


### PR DESCRIPTION
# 🩺 Pull requests
### 📍 작업한 이슈번호
- #

### 💻 작업한 내용
- 상단에 건물은 기본 "새천년관" 이 선택된 상태로 설정
- 이후 다른 건물 클릭해둘 시 기존 버튼의 색상을 이용하여 선택된 것을 표시
- 하단 네비게이션 메뉴는 hover 이벤트 추가(기존 버튼 색상 이용)

### 📢 PR Point
- 

### 📸 스크린샷

Uploading 전심프pr용.mp4…
