### PR TITLE
Api: 홈, 학생인증 페이지 navigation 및 api 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router';
 import router from './shared/router/Router';
 
 function App() {

--- a/src/pages/auth-request/components/saveAuthInfo.tsx
+++ b/src/pages/auth-request/components/saveAuthInfo.tsx
@@ -1,0 +1,9 @@
+const saveAuthInfo = () => {
+  return (
+    <div>
+      
+    </div>
+  )
+}
+
+export default saveAuthInfo

--- a/src/pages/auth-request/components/saveAuthInfo.tsx
+++ b/src/pages/auth-request/components/saveAuthInfo.tsx
@@ -1,9 +1,0 @@
-const saveAuthInfo = () => {
-  return (
-    <div>
-      
-    </div>
-  )
-}
-
-export default saveAuthInfo

--- a/src/pages/auth-request/hooks/useEmailAuthForm.ts
+++ b/src/pages/auth-request/hooks/useEmailAuthForm.ts
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { requestAuthCode, verifyAuthCode } from '../../../shared/apis/auth/auth';
 import { ACCESS_TOKEN } from '../../../shared/constants/storageKey';
 import { requestSpaceOpen } from '../../../shared/apis/open-request/openRequest';
+import { useNavigate } from 'react-router';
 
 export const useEmailAuthForm = () => {
   // 이메일 입력 폼
@@ -62,7 +63,10 @@ export const useEmailAuthForm = () => {
     }
   };
 
-  const handleBack = () => setShowEnterAuth(false);
+  const navigate = useNavigate();
+  const handleBack = () => {
+    navigate(-1);
+  };
 
   return {
     // 이메일 관련

--- a/src/pages/auth-request/hooks/useEmailAuthForm.ts
+++ b/src/pages/auth-request/hooks/useEmailAuthForm.ts
@@ -3,9 +3,12 @@ import { useState } from 'react';
 import { requestAuthCode, verifyAuthCode } from '../../../shared/apis/auth/auth';
 import { ACCESS_TOKEN } from '../../../shared/constants/storageKey';
 import { requestSpaceOpen } from '../../../shared/apis/open-request/openRequest';
-import { useNavigate } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 
 export const useEmailAuthForm = () => {
+  const location = useLocation();
+  const spaceId = location.state?.spaceId;
+
   // 이메일 입력 폼
   const {
     register: registerEmail,
@@ -39,7 +42,7 @@ export const useEmailAuthForm = () => {
         localStorage.setItem(ACCESS_TOKEN, String(response.data.accessToken));
 
         // 개방 요청
-        const result = await requestSpaceOpen(1);
+        const result = await requestSpaceOpen(spaceId);
         console.log(result.data);
       } else {
         setShowEnterAuth(true); // 인증번호 입력 필드 보여주기
@@ -57,6 +60,11 @@ export const useEmailAuthForm = () => {
       const response = await verifyAuthCode(userEmail, authNumber);
       if (response.code === 200) {
         // 인증 성공, accessToken 저장 등 처리
+        // 인증 정보를 저장하시겠어요? 모달창 띄우기,
+        // 동의하면 localStorage에 accessToken 저장하고 개방 요청
+        // 동의안하면 바로 개방 요청
+      } else {
+        // 인증 실패
       }
     } catch {
       alert('인증정보 확인 오류가 발생했습니다.');

--- a/src/pages/main/components/SpaceStatus.tsx
+++ b/src/pages/main/components/SpaceStatus.tsx
@@ -51,7 +51,7 @@ const SpaceStatus = ({
 
   return (
     <div
-      className={`flex w-full items-center justify-between rounded-[10px] border border-gray-200 px-[15px] py-[10px] shadow-[7px] ${openStatus == OPEN_STATUS.LOCKED ? 'bg-red-50' : 'bg-blue-50'}`}
+      className={`flex w-full items-center justify-between rounded-[10px] border border-gray-300 px-[15px] py-[10px] shadow-[7px] ${openStatus == OPEN_STATUS.LOCKED ? 'bg-red-50' : 'bg-blue-50'}`}
     >
       <div className="space-x-[10px]">
         <span className="text-[18px]">

--- a/src/pages/main/components/SpaceStatus.tsx
+++ b/src/pages/main/components/SpaceStatus.tsx
@@ -17,7 +17,7 @@ type SpaceStatusProps = {
 const SpaceStatus = ({
   spaceName,
   openStatus,
-  // spaceId,
+  spaceId,
   requestOrReservedStatus,
 }: SpaceStatusProps) => {
   let buttonText = '';
@@ -46,7 +46,7 @@ const SpaceStatus = ({
   const navigate = useNavigate();
 
   const handleSpaceButtonClick = () => {
-    navigate('/konkuk-student-auth');
+    navigate('/konkuk-student-auth', { state: { spaceId }});
   };
 
   return (

--- a/src/pages/main/components/SpaceStatus.tsx
+++ b/src/pages/main/components/SpaceStatus.tsx
@@ -5,6 +5,7 @@ import {
   REQUEST_OR_RESERVATION_STATUS,
   RequestOrReservationStatus,
 } from '../../../shared/constants/spaceStatus';
+import { useNavigate } from 'react-router';
 
 type SpaceStatusProps = {
   spaceName: string;
@@ -42,6 +43,12 @@ const SpaceStatus = ({
     buttonClass = 'bg-gray-400';
   }
 
+  const navigate = useNavigate();
+
+  const handleSpaceButtonClick = () => {
+    navigate('/konkuk-student-auth');
+  };
+
   return (
     <div
       className={`flex w-full items-center justify-between rounded-[10px] border border-gray-200 px-[15px] py-[10px] shadow-[7px] ${openStatus == OPEN_STATUS.LOCKED ? 'bg-red-50' : 'bg-blue-50'}`}
@@ -69,6 +76,7 @@ const SpaceStatus = ({
             requestOrReservedStatus === REQUEST_OR_RESERVATION_STATUS.NONE
           )
         }
+        onClick={handleSpaceButtonClick}
       >
         {buttonText}
       </button>

--- a/src/shared/apis/auth/auth.ts
+++ b/src/shared/apis/auth/auth.ts
@@ -19,3 +19,12 @@ export const verifyAuthCode = async (userEmail: string, code: number) => {
   const response = await apiClient.post(API.AUTH.VERIFY_AUTH_CODE, requestBody);
   return response.data;
 };
+
+export const saveAuthInfo = async (userEmail: string) => {
+  const requestBody = {
+    email: userEmail,
+  };
+
+  const response = await apiClient.post(API.AUTH.SAVE_AUTH_INFO, requestBody);
+  return response.data;
+};

--- a/src/shared/apis/urls.ts
+++ b/src/shared/apis/urls.ts
@@ -2,7 +2,7 @@ export const API = {
   AUTH: {
     REQUEST_AUTH_CODE: '/auth/code',
     VERIFY_AUTH_CODE: 'auth/verification',
-    REMEMBER_AUTH_INFO: 'auth/memory',
+    SAVE_AUTH_INFO: 'auth/memory',
     ADMIN_LOGIN: 'auth/login',
   },
   OPEN_REQUEST: {


### PR DESCRIPTION
# 🩺 Pull requests
### 📍 작업한 이슈번호
- #13 

### 💻 작업한 내용
- 홈화면-학생인증화면 navigation 구현
- 개방요청 spaceId 하드코딩 해제
- 인증번호 기억하기 api 생성 및 연동

### 📢 PR Point
- 사용자 api 연동 완료(관리자 api는 연동 X)
- 인증번호 기억하기와 인증코드 검증 api는 아직 실제 테스트는 못해봤습니다

### 📸 스크린샷
